### PR TITLE
fix(mqtt5): remove invalid Maximum QoS = 2 from CONNACK

### DIFF
--- a/broker/src/main/kotlin/MqttClient.kt
+++ b/broker/src/main/kotlin/MqttClient.kt
@@ -386,8 +386,8 @@ class MqttClient(
                     // Receive Maximum (33) - Server's limit for outstanding QoS 1/2 messages
                     connackProps.add(MqttProperties.IntegerProperty(33, 100))
                     
-                    // Maximum QoS (36) - Server supports QoS 0, 1, and 2
-                    connackProps.add(MqttProperties.IntegerProperty(36, 2))
+                    // Maximum QoS (36) - Omitted: per MQTT 5.0 §3.2.2.3.4, valid values are 0 or 1 only.
+                    // When absent, the client may use QoS 2. Including value 2 is a protocol error.
                     
                     // Retain Available (37) - Server supports retained messages
                     connackProps.add(MqttProperties.IntegerProperty(37, 1))  // 1 = available
@@ -555,8 +555,8 @@ class MqttClient(
                 // Receive Maximum (33) - Server's limit for outstanding QoS 1/2 messages
                 connackProps.add(MqttProperties.IntegerProperty(33, 100))
                 
-                // Maximum QoS (36) - Server supports QoS 0, 1, and 2
-                connackProps.add(MqttProperties.IntegerProperty(36, 2))
+                // Maximum QoS (36) - Omitted: per MQTT 5.0 §3.2.2.3.4, valid values are 0 or 1 only.
+                // When absent, the client may use QoS 2. Including value 2 is a protocol error.
                 
                 // Retain Available (37) - Server supports retained messages
                 connackProps.add(MqttProperties.IntegerProperty(37, 1))  // 1 = available

--- a/tests/mqtt5/test_mqtt5_server_properties.py
+++ b/tests/mqtt5/test_mqtt5_server_properties.py
@@ -193,15 +193,20 @@ def test_mqtt5_server_properties():
         assert props.ReceiveMaximum > 0, f"Receive Maximum invalid: {props.ReceiveMaximum}"
         
         # Maximum QoS (36)
+        # Per MQTT 5.0 §3.2.2.3.4: valid values are 0 or 1 only. Value 2 is a protocol error.
+        # When absent, the client may use QoS 2 — so absence is the correct signal for full QoS support.
         if hasattr(props, 'MaximumQoS'):
-            if props.MaximumQoS >= 0 and props.MaximumQoS <= 2:
-                print(f"  ✓ Maximum QoS: {props.MaximumQoS}")
+            if 0 <= props.MaximumQoS <= 1:
+                print(f"  ✓ Maximum QoS: {props.MaximumQoS} (broker restricts to QoS {props.MaximumQoS})")
             else:
-                print(f"  ✗ Maximum QoS invalid: {props.MaximumQoS}")
+                print(f"  ✗ Maximum QoS invalid: {props.MaximumQoS} (must be 0 or 1, or absent for QoS 2)")
                 success = False
-        
-        assert hasattr(props, 'MaximumQoS'), "Maximum QoS not present"
-        assert 0 <= props.MaximumQoS <= 2, f"Maximum QoS invalid: {props.MaximumQoS}"
+            assert 0 <= props.MaximumQoS <= 1, (
+                f"Protocol error: Maximum QoS must be 0 or 1 (got {props.MaximumQoS}). "
+                "Value 2 is illegal; omit the property to indicate QoS 2 support."
+            )
+        else:
+            print("  ✓ Maximum QoS: absent (QoS 2 supported, per MQTT 5.0 §3.2.2.3.4)")
         
         # Retain Available (37)
         if hasattr(props, 'RetainAvailable'):


### PR DESCRIPTION
# fix(mqtt5): Remove invalid `Maximum QoS = 2` from CONNACK

**Branch:** `fix-mqtt5-maximum-qos-protocol-error` → `main`  
**PR URL:** https://github.com/KevinJoosten/monster-mq/pull/new/fix-mqtt5-maximum-qos-protocol-error

---

## Summary

MonsterMQ was sending `Maximum QoS = 2` in the MQTT 5.0 CONNACK packet. The MQTT 5.0 spec ([§3.2.2.3.4](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901074)) defines this property as having **only two valid values: `0` or `1`**. Sending `2` is a protocol error that causes strict MQTT 5.0 clients (e.g. MQTTnet 4.x) to reject the connection immediately with `MalformedPacket`.

The fix: **omit the property entirely**, which per spec signals that the client may use QoS 2.

> _If the Maximum QoS is absent, the Client may use QoS 2._  
> — MQTT 5.0 §3.2.2.3.4

---

## Changes

| File | Change |
|------|--------|
| `broker/src/main/kotlin/MqttClient.kt` | Removed `MqttProperties.IntegerProperty(36, 2)` from both the new-session and resumed-session CONNACK builders |
| `tests/mqtt5/test_mqtt5_server_properties.py` | Updated `Maximum QoS` assertion: property must be **absent** (QoS 2 implied) or `0`/`1` if present; removed incorrect assertion that the property must be present |

---

## Root Cause

Both CONNACK builders in `MqttClient.kt` unconditionally emitted:

```kotlin
// ❌ Before — protocol error
connackProps.add(MqttProperties.IntegerProperty(36, 2))
```

---

## Fix

The line is removed in both builders. A comment explains the rationale:

```kotlin
// ✅ After — Maximum QoS (36) omitted:
// Per MQTT 5.0 §3.2.2.3.4, valid values are 0 or 1 only.
// When absent, the client may use QoS 2. Including value 2 is a protocol error.
```

---

## Test Update

`tests/mqtt5/test_mqtt5_server_properties.py`:

- **Before:** asserted `MaximumQoS` must be present and `0 ≤ value ≤ 2`
- **After:** asserts that if present the value must be `0` or `1`; absence is explicitly accepted (and expected for a full QoS 2 broker)

---

## Verification

- `mvn compile` — clean, no errors
- Integration test `test_mqtt5_server_properties.py` updated to pass against the fixed broker
- Confirmed with MQTTnet 4.x: connection now succeeds
