### PR TITLE
feat: support HAZELCAST_CONFIG and HAZELCAST_MEMBERS env vars for cluster discovery

### DIFF
--- a/broker/src/main/kotlin/Monster.kt
+++ b/broker/src/main/kotlin/Monster.kt
@@ -43,6 +43,7 @@ import io.vertx.core.json.JsonArray
 import io.vertx.core.json.JsonObject
 import io.vertx.spi.cluster.hazelcast.HazelcastClusterManager
 import com.hazelcast.config.Config
+import com.hazelcast.config.XmlConfigBuilder
 import at.rocworks.devices.opcua.OpcUaExtension
 import at.rocworks.devices.opcuaserver.OpcUaServerExtension
 import at.rocworks.devices.mqttclient.MqttClientExtension
@@ -837,13 +838,36 @@ MORE INFO:
             }
         )
 
-        // Configure Hazelcast with custom node name
-        val hazelcastConfig = Config()
+        // Load Hazelcast config from HAZELCAST_CONFIG env var, or use defaults
+        val hazelcastConfigFile = System.getenv("HAZELCAST_CONFIG")
+        val hazelcastConfig = if (hazelcastConfigFile != null) {
+            val configFile = java.io.File(hazelcastConfigFile)
+            if (configFile.exists()) {
+                logger.info("Loading Hazelcast config from: $hazelcastConfigFile")
+                java.io.FileInputStream(configFile).use { XmlConfigBuilder(it).build() }
+            } else {
+                logger.warning("Hazelcast config file not found: $hazelcastConfigFile, using default")
+                Config()
+            }
+        } else {
+            Config()
+        }
+
         hazelcastConfig.clusterName = "MonsterMQ"
         hazelcastConfig.memberAttributeConfig.setAttribute("nodeName", this.nodeName)
-
-        // Set instance name to the node name for easier identification
         hazelcastConfig.instanceName = this.nodeName
+
+        // Configure TCP-IP discovery from HAZELCAST_MEMBERS env var
+        val members = System.getenv("HAZELCAST_MEMBERS")
+        if (members != null && members.isNotEmpty()) {
+            logger.info("Configuring TCP-IP discovery with members: $members")
+            val joinConfig = hazelcastConfig.networkConfig.join
+            joinConfig.multicastConfig.isEnabled = false
+            joinConfig.tcpIpConfig.isEnabled = true
+            members.split(",").map { it.trim() }.filter { it.isNotEmpty() }.forEach { member ->
+                joinConfig.tcpIpConfig.addMember(member)
+            }
+        }
 
         this.clusterManager = HazelcastClusterManager(hazelcastConfig)
 


### PR DESCRIPTION
## Problem

When running MonsterMQ in Docker Swarm (overlay networks), Hazelcast cluster formation fails silently. Each node starts as a standalone `Members {size:1}` cluster.

This happens because `clusterSetup()` creates a `Config()` with default multicast discovery, and Docker overlay networks don't support multicast. There's currently no way to configure TCP-IP discovery without modifying the source code.

## Solution

Two new optional environment variables:

- **`HAZELCAST_CONFIG`** — path to a Hazelcast XML config file. If set and the file exists, it's loaded via `XmlConfigBuilder` instead of using defaults. This gives full control over network, join strategy, interfaces, etc.

- **`HAZELCAST_MEMBERS`** — comma-separated list of member addresses (e.g. `node1:5701,node2:5701,node3:5701`). If set, multicast is disabled and TCP-IP join is configured with the given members.

Both are fully backward-compatible — if neither is set, behavior is identical to today.

## Example usage (Docker Swarm)

```yaml
services:
  monstermq:
    image: rocworks/monstermq:latest
    hostname: "{{.Node.Hostname}}-monstermq"
    command:
      - -cluster
    environment:
      HAZELCAST_CONFIG: "/app/hazelcast.xml"
      HAZELCAST_MEMBERS: "ark-node1-monstermq,ark-node2-monstermq,ark-node3-monstermq"
      PUBLIC_ADDRESS: "{{.Node.Hostname}}-monstermq"
    configs:
      - source: hazelcast_config
        target: /app/hazelcast.xml
    deploy:
      replicas: 3
      placement:
        max_replicas_per_node: 1
      endpoint_mode: dnsrr
```

The `hostname` template gives each replica a unique name matching the member list. With `endpoint_mode: dnsrr` and an overlay network, the hostnames resolve to overlay IPs and Hazelcast forms a 3-node cluster via TCP-IP.

## Changes

- `Monster.kt`: 28 lines added to `clusterSetup()`, 4 lines removed
- No new dependencies
- No breaking changes