### PR TITLE
feat(tls): support independent WSS certificate and mTLS for MQTTS

### DIFF
--- a/broker/src/main/kotlin/Monster.kt
+++ b/broker/src/main/kotlin/Monster.kt
@@ -1020,6 +1020,22 @@ MORE INFO:
         val keyStorePath = sslConfig.getString("KeyStorePath", "server-keystore.jks")
         val keyStorePassword = sslConfig.getString("KeyStorePassword", "password")
         val keyStoreType = sslConfig.getString("KeyStoreType", "JKS")
+        val keyPath = sslConfig.getString("KeyPath", "")
+
+        // Optional mutual TLS (client certificate verification) for the MQTTS (TCPS) listener.
+        // Defaults preserve prior behavior exactly: ClientAuth "NONE" means no trust store is applied.
+        val clientAuth = sslConfig.getString("ClientAuth", "NONE")
+        val trustStorePath = sslConfig.getString("TrustStorePath", "")
+        val trustStorePassword = sslConfig.getString("TrustStorePassword", "")
+        val trustStoreType = sslConfig.getString("TrustStoreType", "JKS")
+
+        // Optional independent certificate for the WSS listener. Falls back to the SSL settings
+        // above when not set, so existing single-certificate configs are unaffected.
+        val wssSslConfig = sslConfig.getJsonObject("WSS", JsonObject())
+        val wssKeyStorePath = wssSslConfig.getString("KeyStorePath", keyStorePath)
+        val wssKeyStorePassword = wssSslConfig.getString("KeyStorePassword", keyStorePassword)
+        val wssKeyStoreType = wssSslConfig.getString("KeyStoreType", keyStoreType)
+        val wssKeyPath = wssSslConfig.getString("KeyPath", keyPath)
 
         // Load TCP server configuration
         val tcpServerConfig = configJson.getJsonObject("MqttTcpServer", JsonObject())
@@ -1350,8 +1366,15 @@ MORE INFO:
                 val servers = listOfNotNull(
                     if (useTcp>0) MqttServer(useTcp, false, false, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager) else null,
                     if (useWs>0) MqttServer(useWs, false, true, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager) else null,
-                    if (useTcpSsl>0) MqttServer(useTcpSsl, true, false, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager, keyStorePath, keyStorePassword, keyStoreType) else null,
-                    if (useWsSsl>0) MqttServer(useWsSsl, true, true, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager, keyStorePath, keyStorePassword, keyStoreType) else null,
+                    if (useTcpSsl>0) MqttServer(
+                        useTcpSsl, true, false, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager,
+                        keyStorePath, keyStorePassword, keyStoreType, keyPath,
+                        clientAuth, trustStorePath, trustStorePassword, trustStoreType
+                    ) else null,
+                    if (useWsSsl>0) MqttServer(
+                        useWsSsl, true, true, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager,
+                        wssKeyStorePath, wssKeyStorePassword, wssKeyStoreType, wssKeyPath
+                    ) else null,
                     if (useNats>0) NatsServer(useNats, sessionHandler, userManager) else null,
                     mcpServer,
                     prometheusServer,

--- a/broker/src/main/kotlin/MqttServer.kt
+++ b/broker/src/main/kotlin/MqttServer.kt
@@ -4,9 +4,13 @@ import at.rocworks.auth.UserManager
 import at.rocworks.handlers.SessionHandler
 import io.vertx.core.AbstractVerticle
 import io.vertx.core.Promise
+import io.vertx.core.net.ClientAuth
 import io.vertx.core.net.JksOptions
 import io.vertx.core.net.KeyCertOptions
+import io.vertx.core.net.PemKeyCertOptions
+import io.vertx.core.net.PemTrustOptions
 import io.vertx.core.net.PfxOptions
+import io.vertx.core.net.TrustOptions
 
 import io.vertx.mqtt.MqttServer
 import io.vertx.mqtt.MqttServerOptions
@@ -23,13 +27,28 @@ class MqttServer(
     private val userManager: UserManager,
     private val keyStorePath: String = "server-keystore.jks",
     private val keyStorePassword: String = "password",
-    private val keyStoreType: String = "JKS"
+    private val keyStoreType: String = "JKS",
+    // Private key file path, only used when keyStoreType == "PEM" (keyStorePath is then the cert/fullchain PEM path)
+    private val keyPath: String = "",
+    // Mutual TLS (client certificate verification). Defaults preserve prior behavior exactly: no client auth.
+    private val clientAuth: String = "NONE",
+    private val trustStorePath: String = "",
+    private val trustStorePassword: String = "",
+    private val trustStoreType: String = "JKS"
 ) : AbstractVerticle() {
     private val logger = Utils.getLogger(this::class.java)
 
     private val options = MqttServerOptions().let { it ->
         it.isSsl = ssl
-        it.keyCertOptions = buildKeyCertOptions(keyStorePath, keyStorePassword, keyStoreType)
+        it.keyCertOptions = buildKeyCertOptions(keyStorePath, keyStorePassword, keyStoreType, keyPath)
+        if (clientAuth.uppercase() != "NONE") {
+            if (trustStorePath.isNotBlank()) {
+                it.trustOptions = buildTrustOptions(trustStorePath, trustStorePassword, trustStoreType)
+                it.setClientAuth(ClientAuth.valueOf(clientAuth.uppercase()))
+            } else {
+                logger.warning("SSL ClientAuth is set to '$clientAuth' but no TrustStorePath is configured, so client certificates won't be checked.")
+            }
+        }
         it.isUseWebSocket = this.useWebSocket
         it.maxMessageSize = this.maxMessageSize
         it.isTcpNoDelay = this.tcpNoDelay      // Disable Nagle's algorithm - send packets immediately, don't coalesce
@@ -74,7 +93,12 @@ class MqttServer(
 
         mqttServer.listen(port)
             .onSuccess { server ->
-                logger.info("MQTT Server is listening on port [${server.actualPort()}] [${if (useWebSocket) "WS " else "TCP"}][${if (ssl) "TLS" else "   "}]")
+                val tlsLabel = when {
+                    !ssl -> "   "
+                    clientAuth.uppercase() != "NONE" && trustStorePath.isNotBlank() -> "mTLS"
+                    else -> "TLS"
+                }
+                logger.info("MQTT Server is listening on port [${server.actualPort()}] [${if (useWebSocket) "WS " else "TCP"}][$tlsLabel]")
                 startPromise.complete()
             }
             .onFailure { error ->
@@ -84,9 +108,17 @@ class MqttServer(
     }
 
     companion object {
-        fun buildKeyCertOptions(path: String, password: String, type: String): KeyCertOptions =
+        fun buildKeyCertOptions(path: String, password: String, type: String, keyPath: String = ""): KeyCertOptions =
             when (type.uppercase()) {
                 "PKCS12", "PFX", "P12" -> PfxOptions().setPath(path).setPassword(password)
+                "PEM" -> PemKeyCertOptions().setCertPath(path).setKeyPath(keyPath.ifBlank { path })
+                else -> JksOptions().setPath(path).setPassword(password)
+            }
+
+        fun buildTrustOptions(path: String, password: String, type: String): TrustOptions =
+            when (type.uppercase()) {
+                "PKCS12", "PFX", "P12" -> PfxOptions().setPath(path).setPassword(password)
+                "PEM" -> PemTrustOptions().addCertPath(path)
                 else -> JksOptions().setPath(path).setPassword(password)
             }
     }

--- a/broker/yaml-json-schema.json
+++ b/broker/yaml-json-schema.json
@@ -397,26 +397,90 @@
     "SSL": {
       "type": "object",
       "title": "SSL / TLS Encryption",
-      "description": "SSL/TLS certificate configuration for encrypted MQTT connections (TCPS and WSS)",
+      "description": "SSL/TLS certificate configuration for encrypted MQTT connections (TCPS and WSS). These settings are used by the MQTTS (TCPS) listener, and also serve as the fallback for the WSS listener when the optional 'WSS' override below is not set.",
       "properties": {
         "KeyStorePath": {
           "type": "string",
           "title": "KeyStore File Path",
-          "description": "Path to the keystore file containing the server certificate and private key",
+          "description": "Path to the keystore file containing the server certificate and private key. When KeyStoreType is PEM, this is the certificate (or fullchain) PEM file path instead.",
           "default": "server-keystore.jks"
         },
         "KeyStorePassword": {
           "type": "string",
           "title": "KeyStore Password",
-          "description": "Password for accessing the keystore file",
+          "description": "Password for accessing the keystore file. Ignored when KeyStoreType is PEM.",
           "default": "password"
         },
         "KeyStoreType": {
           "type": "string",
           "title": "KeyStore Format",
-          "enum": ["JKS", "PKCS12", "PFX", "P12"],
-          "description": "Keystore format: JKS (Java KeyStore) or PKCS12 / PFX / P12 (industry standard).",
+          "enum": ["JKS", "PKCS12", "PFX", "P12", "PEM"],
+          "description": "Keystore format: JKS (Java KeyStore), PKCS12 / PFX / P12 (industry standard), or PEM (separate certificate + private key files, e.g. from Let's Encrypt/certbot).",
           "default": "JKS"
+        },
+        "KeyPath": {
+          "type": "string",
+          "title": "Private Key File Path (PEM only)",
+          "description": "Path to the private key PEM file. Only used when KeyStoreType is PEM.",
+          "default": ""
+        },
+        "ClientAuth": {
+          "type": "string",
+          "title": "Client Certificate Verification",
+          "enum": ["NONE", "REQUEST", "REQUIRED"],
+          "description": "Enables mutual TLS (mTLS) on the MQTTS (TCPS) listener by requesting/requiring a client certificate, verified against TrustStorePath. NONE is the default and matches prior behavior (no client certificate requested). Not applied to the WSS listener.",
+          "default": "NONE"
+        },
+        "TrustStorePath": {
+          "type": "string",
+          "title": "TrustStore / CA File Path",
+          "description": "Path to a truststore (JKS/PKCS12) or a CA certificate PEM file (when TrustStoreType is PEM) used to verify client certificates when ClientAuth is REQUEST or REQUIRED.",
+          "default": ""
+        },
+        "TrustStorePassword": {
+          "type": "string",
+          "title": "TrustStore Password",
+          "description": "Password for accessing the truststore file. Ignored when TrustStoreType is PEM.",
+          "default": ""
+        },
+        "TrustStoreType": {
+          "type": "string",
+          "title": "TrustStore Format",
+          "enum": ["JKS", "PKCS12", "PFX", "P12", "PEM"],
+          "description": "Truststore format: JKS, PKCS12 / PFX / P12, or PEM (a single CA certificate file).",
+          "default": "JKS"
+        },
+        "WSS": {
+          "type": "object",
+          "title": "WSS Listener Certificate Override",
+          "description": "Optional independent certificate for the Secure WebSocket (WSS) listener. Falls back to the KeyStore settings above when not set. Use this when WSS should present a different certificate than MQTTS, e.g. a public domain certificate for WSS and an internal CA-issued certificate for MQTTS. There's no ClientAuth/TrustStore here since WSS stays server-authenticated TLS only.",
+          "properties": {
+            "KeyStorePath": {
+              "type": "string",
+              "title": "KeyStore File Path",
+              "description": "Path to the keystore file (or certificate/fullchain PEM file when KeyStoreType is PEM) for the WSS listener.",
+              "default": ""
+            },
+            "KeyStorePassword": {
+              "type": "string",
+              "title": "KeyStore Password",
+              "description": "Password for accessing the WSS keystore file. Ignored when KeyStoreType is PEM.",
+              "default": ""
+            },
+            "KeyStoreType": {
+              "type": "string",
+              "title": "KeyStore Format",
+              "enum": ["JKS", "PKCS12", "PFX", "P12", "PEM"],
+              "description": "Keystore format for the WSS certificate.",
+              "default": "JKS"
+            },
+            "KeyPath": {
+              "type": "string",
+              "title": "Private Key File Path (PEM only)",
+              "description": "Path to the WSS private key PEM file. Only used when KeyStoreType is PEM.",
+              "default": ""
+            }
+          }
         }
       }
     },

--- a/doc/security.md
+++ b/doc/security.md
@@ -20,17 +20,21 @@ Security features include:
 # Enable TLS on MQTT port
 TCPS: 8883
 
+# Enable TLS on the Secure WebSocket port
+WSS: 8884
+
 # Optional: Configure keystore (defaults shown)
 SSL:
   KeyStorePath: server-keystore.jks
   KeyStorePassword: password
+  KeyStoreType: JKS   # JKS (default) | PKCS12 / PFX / P12 | PEM
 ```
 
 By default, MonsterMQ looks for `server-keystore.jks` in the working directory with password `password`. You can customize this using the `SSL` configuration section.
 
 ### Certificate Requirements
 
-MonsterMQ requires a Java KeyStore (JKS) file for SSL/TLS functionality:
+`SSL.KeyStoreType` can be `JKS` (default), `PKCS12`/`PFX`/`P12`, or `PEM`. For `PEM`, point `SSL.KeyStorePath` at the certificate (or fullchain) file and `SSL.KeyPath` at the private key file - useful if you're using certs straight off certbot/Let's Encrypt without converting them first.
 
 - **Default filename**: `server-keystore.jks` (configurable via `SSL.KeyStorePath`)
 - **Default password**: `password` (configurable via `SSL.KeyStorePassword`)
@@ -92,9 +96,38 @@ keytool -importkeystore \
   -deststorepass changeit
 ```
 
-### Client Certificate Authentication
+### Different Certificates for TCPS and WSS
 
-Client certificate authentication is not currently configurable in MonsterMQ. The SSL implementation only supports server certificates for encrypted communication.
+`WSS` uses the same certificate as `TCPS` unless you override it. This is handy if, say, your WSS listener needs a normal domain cert for browser clients but MQTTS should use a cert from your own internal CA:
+
+```yaml
+SSL:
+  KeyStorePath: mqtts-server.p12   # used by TCPS, and by WSS unless overridden below
+  KeyStorePassword: password
+  KeyStoreType: PKCS12
+  WSS:
+    KeyStorePath: domain-cert.p12  # only used by WSS
+    KeyStorePassword: password
+    KeyStoreType: PKCS12
+```
+
+Leave out whichever fields you don't need to change in the `WSS` block - they fall back to the top-level `SSL` value.
+
+### Client Certificate Authentication (Mutual TLS)
+
+MQTTS can also require clients to present a certificate, verified against a trust store with your CA cert. `WSS` doesn't support this - it stays server-auth only.
+
+```yaml
+SSL:
+  KeyStorePath: mqtts-server.jks
+  KeyStorePassword: password
+  ClientAuth: REQUIRED              # NONE (default), REQUEST, or REQUIRED
+  TrustStorePath: ca-truststore.jks  # or a CA .crt with TrustStoreType: PEM
+  TrustStorePassword: password
+  TrustStoreType: JKS
+```
+
+`NONE` is the default and behaves exactly like before. `REQUEST` asks for a client cert but still connects if none is given. `REQUIRED` fails the handshake unless the client presents a cert that verifies against `TrustStorePath`.
 
 ## Authentication
 


### PR DESCRIPTION
**Summary**: MQTTS and WSS currently share one certificate via a single SSL block. We need them independent — WSS should use a normal domain cert, MQTTS needs mutual TLS with our own CA. This adds an optional SSL.WSS override for a separate WSS cert, plus ClientAuth/TrustStore* settings for mTLS on MQTTS. PEM keystores are also supported now, not just JKS/PKCS12.

**Changes**: Monster.kt, MqttServer.kt, yaml-json-schema.json, doc/security.md.

**Testing**: I will be running this in parallel on our own setup (the mTLS MQTTS + domain-cert WSS split described) and can report back on how that goes but would appreciate build/review pass before this gets merged into main.

[DEV_NOTES.md](https://github.com/user-attachments/files/31675714/DEV_NOTES.md)