### PR TITLE
Use client certificate Common Name as username for mTLS clients

### DIFF
--- a/broker/src/main/kotlin/Monster.kt
+++ b/broker/src/main/kotlin/Monster.kt
@@ -1028,6 +1028,9 @@ MORE INFO:
         val trustStorePath = sslConfig.getString("TrustStorePath", "")
         val trustStorePassword = sslConfig.getString("TrustStorePassword", "")
         val trustStoreType = sslConfig.getString("TrustStoreType", "JKS")
+        // Use the verified client certificate's Common Name as the authenticated
+        // identity, skipping passwords.
+        val useIdentityAsUsername = sslConfig.getBoolean("UseIdentityAsUsername", false)
 
         // Optional independent certificate for the WSS listener. Falls back to the SSL settings
         // above when not set, so existing single-certificate configs are unaffected.
@@ -1369,7 +1372,7 @@ MORE INFO:
                     if (useTcpSsl>0) MqttServer(
                         useTcpSsl, true, false, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager,
                         keyStorePath, keyStorePassword, keyStoreType, keyPath,
-                        clientAuth, trustStorePath, trustStorePassword, trustStoreType
+                        clientAuth, trustStorePath, trustStorePassword, trustStoreType, useIdentityAsUsername
                     ) else null,
                     if (useWsSsl>0) MqttServer(
                         useWsSsl, true, true, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager,

--- a/broker/src/main/kotlin/Monster.kt
+++ b/broker/src/main/kotlin/Monster.kt
@@ -1031,6 +1031,8 @@ MORE INFO:
         // Use the verified client certificate's Common Name as the authenticated
         // identity, skipping passwords.
         val useIdentityAsUsername = sslConfig.getBoolean("UseIdentityAsUsername", false)
+        // Create a user account automatically for a certificate Common Name that has none yet.
+        val autoCreateUser = sslConfig.getBoolean("AutoCreateUser", false)
 
         // Optional independent certificate for the WSS listener. Falls back to the SSL settings
         // above when not set, so existing single-certificate configs are unaffected.
@@ -1372,7 +1374,7 @@ MORE INFO:
                     if (useTcpSsl>0) MqttServer(
                         useTcpSsl, true, false, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager,
                         keyStorePath, keyStorePassword, keyStoreType, keyPath,
-                        clientAuth, trustStorePath, trustStorePassword, trustStoreType, useIdentityAsUsername
+                        clientAuth, trustStorePath, trustStorePassword, trustStoreType, useIdentityAsUsername, autoCreateUser
                     ) else null,
                     if (useWsSsl>0) MqttServer(
                         useWsSsl, true, true, maxMessageSize, tcpNoDelay, receiveBufferSize, sendBufferSize, sessionHandler, userManager,

--- a/broker/src/main/kotlin/MqttClient.kt
+++ b/broker/src/main/kotlin/MqttClient.kt
@@ -30,7 +30,11 @@ import java.util.concurrent.ConcurrentLinkedDeque
 class MqttClient(
     private val endpoint: MqttEndpoint,
     private val sessionHandler: SessionHandler,
-    private val userManager: UserManager
+    private val userManager: UserManager,
+    // When true, a verified TLS client certificate's Common Name is used as the client's
+    // authenticated identity, skipping password checks. Defaults to false so existing
+    // setups are unaffected.
+    private val useIdentityAsUsername: Boolean = false
 ): AbstractVerticle() {
     private val logger = Utils.getLogger(this::class.java)
 
@@ -128,11 +132,11 @@ class MqttClient(
         private val logger = Utils.getLogger(this::class.java)
 
 
-        fun deployEndpoint(vertx: Vertx, endpoint: MqttEndpoint, sessionHandler: SessionHandler, userManager: UserManager) {
+        fun deployEndpoint(vertx: Vertx, endpoint: MqttEndpoint, sessionHandler: SessionHandler, userManager: UserManager, useIdentityAsUsername: Boolean = false) {
             val clientId = endpoint.clientIdentifier()
             logger.fine { "Client [${clientId}] Deploy a new session for [${endpoint.remoteAddress()}] [${Utils.getCurrentFunctionName()}]" }
             // TODO: check if the client is already connected (cluster wide)
-            val client = MqttClient(endpoint, sessionHandler, userManager)
+            val client = MqttClient(endpoint, sessionHandler, userManager, useIdentityAsUsername)
             vertx.deployVerticle(client).onComplete {
                 client.startEndpoint()
             }
@@ -487,6 +491,26 @@ class MqttClient(
 
             // Authentication check
             if (userManager.isUserManagementEnabled()) {
+                // If enabled, a verified TLS client certificate's Common Name becomes the
+                // authenticated identity directly - the certificate was already validated
+                // against the trusted CA during the TLS handshake, so no password is needed.
+                if (useIdentityAsUsername) {
+                    val certUsername = extractPeerCertificateCommonName()
+                    if (certUsername != null) {
+                        authenticatedUser = at.rocworks.data.User(
+                            username = certUsername,
+                            passwordHash = "",
+                            enabled = true,
+                            canSubscribe = true,
+                            canPublish = true,
+                            isAdmin = false
+                        )
+                        logger.info("Client [$clientId] Authenticated via TLS client certificate as [$certUsername]")
+                        proceedWithConnection()
+                        return
+                    }
+                }
+
                 // Check for MQTT v5.0 enhanced authentication first
                 if (isMqtt5 && mqtt5AuthMethod != null) {
                     // Enhanced authentication requested
@@ -550,6 +574,25 @@ class MqttClient(
                 // Authentication disabled, proceed normally
                 proceedWithConnection()
             }
+        }
+    }
+
+    // Extracts the Common Name from the client's TLS certificate, if one was presented.
+    // Returns null (rather than throwing) whenever no usable client certificate is
+    // available - e.g. ClientAuth is REQUEST and the client didn't offer one, or the
+    // connection isn't TLS at all. That's the normal/expected case, not an error.
+    private fun extractPeerCertificateCommonName(): String? {
+        if (!endpoint.isSsl) return null
+        return try {
+            val cert = endpoint.sslSession()?.peerCertificates?.firstOrNull() as? java.security.cert.X509Certificate
+                ?: return null
+            val ldapName = javax.naming.ldap.LdapName(cert.subjectX500Principal.name)
+            ldapName.rdns.firstOrNull { it.type.equals("CN", ignoreCase = true) }?.value?.toString()
+        } catch (e: javax.net.ssl.SSLPeerUnverifiedException) {
+            null
+        } catch (e: Exception) {
+            logger.warning("Client [$clientId] Failed to read Common Name from client certificate: ${e.message}")
+            null
         }
     }
 

--- a/broker/src/main/kotlin/MqttClient.kt
+++ b/broker/src/main/kotlin/MqttClient.kt
@@ -34,7 +34,11 @@ class MqttClient(
     // When true, a verified TLS client certificate's Common Name is used as the client's
     // authenticated identity, skipping password checks. Defaults to false so existing
     // setups are unaffected.
-    private val useIdentityAsUsername: Boolean = false
+    private val useIdentityAsUsername: Boolean = false,
+    // When true, a client certificate whose Common Name has no user account yet gets one
+    // created automatically with default, non-admin permissions. When false, such a client
+    // is rejected and accounts must be created up front.
+    private val autoCreateUser: Boolean = false
 ): AbstractVerticle() {
     private val logger = Utils.getLogger(this::class.java)
 
@@ -132,11 +136,11 @@ class MqttClient(
         private val logger = Utils.getLogger(this::class.java)
 
 
-        fun deployEndpoint(vertx: Vertx, endpoint: MqttEndpoint, sessionHandler: SessionHandler, userManager: UserManager, useIdentityAsUsername: Boolean = false) {
+        fun deployEndpoint(vertx: Vertx, endpoint: MqttEndpoint, sessionHandler: SessionHandler, userManager: UserManager, useIdentityAsUsername: Boolean = false, autoCreateUser: Boolean = false) {
             val clientId = endpoint.clientIdentifier()
             logger.fine { "Client [${clientId}] Deploy a new session for [${endpoint.remoteAddress()}] [${Utils.getCurrentFunctionName()}]" }
             // TODO: check if the client is already connected (cluster wide)
-            val client = MqttClient(endpoint, sessionHandler, userManager, useIdentityAsUsername)
+            val client = MqttClient(endpoint, sessionHandler, userManager, useIdentityAsUsername, autoCreateUser)
             vertx.deployVerticle(client).onComplete {
                 client.startEndpoint()
             }
@@ -491,22 +495,53 @@ class MqttClient(
 
             // Authentication check
             if (userManager.isUserManagementEnabled()) {
-                // If enabled, a verified TLS client certificate's Common Name becomes the
-                // authenticated identity directly - the certificate was already validated
-                // against the trusted CA during the TLS handshake, so no password is needed.
+                // If enabled, a verified TLS client certificate's Common Name identifies the
+                // client - the certificate was already validated against the trusted CA during
+                // the TLS handshake, so it replaces the password. The user account still governs
+                // permissions and ACL rules, exactly like a password-authenticated user.
                 if (useIdentityAsUsername) {
                     val certUsername = extractPeerCertificateCommonName()
                     if (certUsername != null) {
-                        authenticatedUser = at.rocworks.data.User(
+                        val existingUser = userManager.getUser(certUsername)
+                        if (existingUser != null) {
+                            if (!existingUser.enabled) {
+                                logger.warning("Client [$clientId] Certificate user [$certUsername] is disabled - rejecting connection")
+                                rejectAndCloseEndpoint(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED)
+                                return
+                            }
+                            authenticatedUser = existingUser
+                            logger.info("Client [$clientId] Authenticated via TLS client certificate as [$certUsername]")
+                            proceedWithConnection()
+                            return
+                        }
+
+                        if (!autoCreateUser) {
+                            logger.warning("Client [$clientId] No user account for certificate Common Name [$certUsername] - rejecting connection")
+                            rejectAndCloseEndpoint(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED)
+                            return
+                        }
+
+                        // Create the account with default, non-admin permissions. The password is a
+                        // random value that is never stored anywhere else, so the account cannot be
+                        // used for password authentication - the certificate remains the credential.
+                        userManager.createUser(
                             username = certUsername,
-                            passwordHash = "",
+                            password = java.util.UUID.randomUUID().toString(),
                             enabled = true,
                             canSubscribe = true,
                             canPublish = true,
                             isAdmin = false
-                        )
-                        logger.info("Client [$clientId] Authenticated via TLS client certificate as [$certUsername]")
-                        proceedWithConnection()
+                        ).onComplete { created ->
+                            val newUser = if (created.succeeded() && created.result()) userManager.getUser(certUsername) else null
+                            if (newUser != null) {
+                                authenticatedUser = newUser
+                                logger.info("Client [$clientId] Created user [$certUsername] from client certificate and authenticated")
+                                proceedWithConnection()
+                            } else {
+                                logger.warning("Client [$clientId] Could not create user [$certUsername] from client certificate - rejecting connection")
+                                rejectAndCloseEndpoint(MqttConnectReturnCode.CONNECTION_REFUSED_NOT_AUTHORIZED)
+                            }
+                        }
                         return
                     }
                 }
@@ -587,7 +622,8 @@ class MqttClient(
             val cert = endpoint.sslSession()?.peerCertificates?.firstOrNull() as? java.security.cert.X509Certificate
                 ?: return null
             val ldapName = javax.naming.ldap.LdapName(cert.subjectX500Principal.name)
-            ldapName.rdns.firstOrNull { it.type.equals("CN", ignoreCase = true) }?.value?.toString()
+            val commonName = ldapName.rdns.firstOrNull { it.type.equals("CN", ignoreCase = true) }?.value?.toString()?.trim()
+            if (commonName.isNullOrBlank()) null else commonName
         } catch (e: javax.net.ssl.SSLPeerUnverifiedException) {
             null
         } catch (e: Exception) {

--- a/broker/src/main/kotlin/MqttServer.kt
+++ b/broker/src/main/kotlin/MqttServer.kt
@@ -34,7 +34,10 @@ class MqttServer(
     private val clientAuth: String = "NONE",
     private val trustStorePath: String = "",
     private val trustStorePassword: String = "",
-    private val trustStoreType: String = "JKS"
+    private val trustStoreType: String = "JKS",
+    // When true, a verified client certificate's Common Name is used as the client's
+    // authenticated identity instead of a username/password. Defaults to false.
+    private val useIdentityAsUsername: Boolean = false
 ) : AbstractVerticle() {
     private val logger = Utils.getLogger(this::class.java)
 
@@ -88,7 +91,7 @@ class MqttServer(
         }
 
         mqttServer.endpointHandler { endpoint ->
-            MqttClient.deployEndpoint(vertx, endpoint, sessionHandler, userManager)
+            MqttClient.deployEndpoint(vertx, endpoint, sessionHandler, userManager, useIdentityAsUsername)
         }
 
         mqttServer.listen(port)

--- a/broker/src/main/kotlin/MqttServer.kt
+++ b/broker/src/main/kotlin/MqttServer.kt
@@ -37,7 +37,10 @@ class MqttServer(
     private val trustStoreType: String = "JKS",
     // When true, a verified client certificate's Common Name is used as the client's
     // authenticated identity instead of a username/password. Defaults to false.
-    private val useIdentityAsUsername: Boolean = false
+    private val useIdentityAsUsername: Boolean = false,
+    // When true, a certificate Common Name without an existing user account gets one created
+    // automatically with default, non-admin permissions. Defaults to false.
+    private val autoCreateUser: Boolean = false
 ) : AbstractVerticle() {
     private val logger = Utils.getLogger(this::class.java)
 
@@ -91,7 +94,7 @@ class MqttServer(
         }
 
         mqttServer.endpointHandler { endpoint ->
-            MqttClient.deployEndpoint(vertx, endpoint, sessionHandler, userManager, useIdentityAsUsername)
+            MqttClient.deployEndpoint(vertx, endpoint, sessionHandler, userManager, useIdentityAsUsername, autoCreateUser)
         }
 
         mqttServer.listen(port)

--- a/broker/yaml-json-schema.json
+++ b/broker/yaml-json-schema.json
@@ -450,6 +450,12 @@
           "description": "Truststore format: JKS, PKCS12 / PFX / P12, or PEM (a single CA certificate file).",
           "default": "JKS"
         },
+        "UseIdentityAsUsername": {
+          "type": "boolean",
+          "title": "Use Certificate Common Name as Username",
+          "description": "When ClientAuth is REQUEST or REQUIRED and the client presents a valid certificate, its Common Name (CN) is used directly as the authenticated identity, skipping password checks. Only applies to the MQTTS (TCPS) listener; has no effect if the client presents no certificate or if UserManagement is disabled.",
+          "default": false
+        },
         "WSS": {
           "type": "object",
           "title": "WSS Listener Certificate Override",

--- a/broker/yaml-json-schema.json
+++ b/broker/yaml-json-schema.json
@@ -453,7 +453,13 @@
         "UseIdentityAsUsername": {
           "type": "boolean",
           "title": "Use Certificate Common Name as Username",
-          "description": "When ClientAuth is REQUEST or REQUIRED and the client presents a valid certificate, its Common Name (CN) is used directly as the authenticated identity, skipping password checks. Only applies to the MQTTS (TCPS) listener; has no effect if the client presents no certificate or if UserManagement is disabled.",
+          "description": "When ClientAuth is REQUEST or REQUIRED and the client presents a valid certificate, its Common Name (CN) is used as the authenticated identity and the password check is skipped. The matching user account still governs permissions and ACL rules, and a disabled account is rejected. Only applies to the MQTTS (TCPS) listener; has no effect if the client presents no certificate or if UserManagement is disabled.",
+          "default": false
+        },
+        "AutoCreateUser": {
+          "type": "boolean",
+          "title": "Auto-Create User For Certificate Common Name",
+          "description": "Only used together with UseIdentityAsUsername. When false (default), a certificate whose Common Name has no user account is rejected, so accounts must be created up front. When true, the account is created automatically on first connect with default, non-admin permissions.",
           "default": false
         },
         "WSS": {

--- a/doc/security.md
+++ b/doc/security.md
@@ -129,6 +129,24 @@ SSL:
 
 `NONE` is the default and behaves exactly like before. `REQUEST` asks for a client cert but still connects if none is given. `REQUIRED` fails the handshake unless the client presents a cert that verifies against `TrustStorePath`.
 
+### Using the Certificate as the Login (No Password Needed)
+
+With `ClientAuth: REQUEST` or `REQUIRED`, you can also skip password authentication entirely for clients that present a certificate - their certificate's Common Name becomes their identity instead.
+
+```yaml
+UserManagement:
+  Enabled: true
+SSL:
+  ClientAuth: REQUEST                # cert optional, so non-cert clients can still use a password
+  TrustStorePath: ca.crt
+  TrustStoreType: PEM
+  UseIdentityAsUsername: true
+```
+
+A client presenting a certificate signed by the CA in `TrustStorePath` connects immediately, authenticated as the certificate's CN, no username or password required. A client with no certificate falls back to the normal username/password check. Both kinds of clients can connect to the same port at once.
+
+The certificate is already verified against the CA during the TLS handshake before this ever kicks in, so no separate user record needs to exist for that CN - the CA signature is treated as sufficient proof of identity. Per-topic permissions still work the same way they do for any other user.
+
 ## Authentication
 
 ### Username/Password Authentication

--- a/doc/security.md
+++ b/doc/security.md
@@ -131,7 +131,7 @@ SSL:
 
 ### Using the Certificate as the Login (No Password Needed)
 
-With `ClientAuth: REQUEST` or `REQUIRED`, you can also skip password authentication entirely for clients that present a certificate - their certificate's Common Name becomes their identity instead.
+With `ClientAuth: REQUEST` or `REQUIRED`, you can skip password authentication for clients that present a certificate - the certificate's Common Name becomes their username instead.
 
 ```yaml
 UserManagement:
@@ -141,11 +141,18 @@ SSL:
   TrustStorePath: ca.crt
   TrustStoreType: PEM
   UseIdentityAsUsername: true
+  AutoCreateUser: false              # true to create accounts on first connect
 ```
 
-A client presenting a certificate signed by the CA in `TrustStorePath` connects immediately, authenticated as the certificate's CN, no username or password required. A client with no certificate falls back to the normal username/password check. Both kinds of clients can connect to the same port at once.
+A client presenting a certificate signed by the CA in `TrustStorePath` is authenticated as the certificate's Common Name, with no username or password required. A client with no certificate falls back to the normal username and password check, so both kinds of clients can use the same port.
 
-The certificate is already verified against the CA during the TLS handshake before this ever kicks in, so no separate user record needs to exist for that CN - the CA signature is treated as sufficient proof of identity. Per-topic permissions still work the same way they do for any other user.
+The certificate only replaces the password. The user account still decides what the client may do:
+
+- If an account exists for that Common Name, it is used, so its `canPublish`, `canSubscribe` and ACL rules apply exactly as they would for a password user.
+- If the account is disabled, the connection is rejected. This is how you cut off a decommissioned or compromised device.
+- If no account exists, the connection is rejected unless `AutoCreateUser` is enabled.
+
+With `AutoCreateUser: true`, a certificate Common Name that has no account yet gets one created on first connect, with default non-admin permissions. This suits device fleets where every device already carries a certificate from your own CA and you do not want to create accounts by hand. The account is created with a random password that is never used, so it cannot be used to log in with a password. Set it to `false` when you would rather create every account up front and reject anything unknown.
 
 ## Authentication
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -30,3 +30,4 @@ markers =
     external: Non-MQTT external interface regression tests
     flow: Flow Engine end-to-end tests (requires FlowEngine feature)
     i3x: i3X v1 API tests (requires broker with I3x.Enabled=true)
+    mtls: Mutual TLS client certificate tests (requires broker with ClientAuth and client certs)

--- a/tests/pytest_tests/conftest.py
+++ b/tests/pytest_tests/conftest.py
@@ -4,7 +4,7 @@ Pytest configuration and shared fixtures for Monster-MQ tests.
 Environment variables for skipping test groups:
   SKIP_MQTT3=1, SKIP_MQTT5=1, SKIP_GRAPHQL=1, SKIP_OPCUA=1,
   SKIP_DATABASE=1, SKIP_FLOW=1, SKIP_REST=1, SKIP_QUEUING=1,
-  SKIP_LATENCY=1, SKIP_I3X=1
+  SKIP_LATENCY=1, SKIP_I3X=1, SKIP_MTLS=1
 """
 import os
 import time
@@ -24,6 +24,7 @@ _SKIP_DIRS = {
     "queuing": os.getenv("SKIP_QUEUING", "0") == "1",
     "latency": os.getenv("SKIP_LATENCY", "0") == "1",
     "i3x": os.getenv("SKIP_I3X", "0") == "1",
+    "mtls": os.getenv("SKIP_MTLS", "0") == "1",
 }
 
 

--- a/tests/pytest_tests/mtls/conftest.py
+++ b/tests/pytest_tests/mtls/conftest.py
@@ -1,0 +1,62 @@
+"""
+Fixtures for mutual TLS (client certificate) tests.
+
+These tests need a broker listening on a TLS port with client certificate
+authentication enabled, for example:
+
+    TCPS: 8883
+    UserManagement:
+      Enabled: true
+    SSL:
+      KeyStoreType: PEM
+      KeyStorePath: server.crt
+      KeyPath: server.key
+      ClientAuth: REQUEST
+      TrustStoreType: PEM
+      TrustStorePath: ca.crt
+      UseIdentityAsUsername: true
+      AutoCreateUser: true
+
+Environment variables:
+  MQTT_MTLS_PORT     TLS port of the broker (default: 8883)
+  MTLS_CA_CERT       CA certificate that signed the broker and client certificates
+  MTLS_CLIENT_CERT   client certificate to present
+  MTLS_CLIENT_KEY    private key for the client certificate
+  MTLS_CLIENT_CN     Common Name inside the client certificate (default: test-client)
+  MTLS_TLS_INSECURE  set to 1 to skip broker hostname verification (default: 1)
+  MTLS_AUTO_CREATE_USER  1 if the broker runs with SSL.AutoCreateUser enabled, 0 if
+                     disabled. The tests for those two modes are skipped unless this
+                     is set, since a broker can only run in one of them at a time.
+  GRAPHQL_URL        GraphQL endpoint used to manage accounts (default: http://localhost:4000/graphql)
+
+The whole group is skipped when the certificate paths are not provided.
+"""
+import os
+import pytest
+
+
+@pytest.fixture(scope="session")
+def mtls_config():
+    ca = os.getenv("MTLS_CA_CERT")
+    cert = os.getenv("MTLS_CLIENT_CERT")
+    key = os.getenv("MTLS_CLIENT_KEY")
+
+    missing = [name for name, value in
+               (("MTLS_CA_CERT", ca), ("MTLS_CLIENT_CERT", cert), ("MTLS_CLIENT_KEY", key))
+               if not value]
+    if missing:
+        pytest.skip("mTLS tests need " + ", ".join(missing))
+
+    for name, path in (("MTLS_CA_CERT", ca), ("MTLS_CLIENT_CERT", cert), ("MTLS_CLIENT_KEY", key)):
+        if not os.path.isfile(path):
+            pytest.skip("{} does not point at a file: {}".format(name, path))
+
+    return {
+        "host": os.getenv("MQTT_BROKER", "localhost"),
+        "port": int(os.getenv("MQTT_MTLS_PORT", "8883")),
+        "ca_cert": ca,
+        "client_cert": cert,
+        "client_key": key,
+        "common_name": os.getenv("MTLS_CLIENT_CN", "test-client"),
+        "insecure": os.getenv("MTLS_TLS_INSECURE", "1") == "1",
+    }

--- a/tests/pytest_tests/mtls/test_client_certificate_auth.py
+++ b/tests/pytest_tests/mtls/test_client_certificate_auth.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Client certificate (mutual TLS) authentication tests.
+
+Covers SSL.UseIdentityAsUsername, where the certificate Common Name is used as
+the authenticated username instead of a password.
+"""
+import os
+import threading
+import time
+import uuid
+
+import paho.mqtt.client as mqtt
+import pytest
+import requests
+
+pytestmark = pytest.mark.mtls
+
+GRAPHQL_URL = os.getenv("GRAPHQL_URL", "http://localhost:4000/graphql")
+ADMIN_USER = os.getenv("MQTT_ADMIN_USERNAME", "Admin")
+ADMIN_PASSWORD = os.getenv("MQTT_ADMIN_PASSWORD", "Admin")
+# "1" when the broker under test has SSL.AutoCreateUser enabled, "0" when disabled.
+AUTO_CREATE = os.getenv("MTLS_AUTO_CREATE_USER", "")
+
+
+def _make_client(client_id, mtls_config, with_certificate=True, username=None, password=None):
+    """Build an MQTT 3.1.1 client, optionally presenting a client certificate."""
+    unique_id = "{}_{}".format(client_id, uuid.uuid4().hex[:8])
+    c = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, unique_id, protocol=mqtt.MQTTv311)
+
+    if with_certificate:
+        c.tls_set(ca_certs=mtls_config["ca_cert"],
+                  certfile=mtls_config["client_cert"],
+                  keyfile=mtls_config["client_key"])
+    else:
+        c.tls_set(ca_certs=mtls_config["ca_cert"])
+    if mtls_config["insecure"]:
+        c.tls_insecure_set(True)
+
+    if username is not None:
+        c.username_pw_set(username, password)
+
+    c._connack_event = threading.Event()
+    c._suback_event = threading.Event()
+    c._messages = []
+    c._rc = None
+
+    def on_connect(client, userdata, flags, rc, properties=None):
+        client._rc = rc
+        client._connack_event.set()
+
+    def on_subscribe(client, userdata, mid, reason_code_list, properties=None):
+        client._suback_event.set()
+
+    def on_message(client, userdata, msg):
+        client._messages.append((msg.topic, msg.payload.decode()))
+
+    c.on_connect = on_connect
+    c.on_subscribe = on_subscribe
+    c.on_message = on_message
+    return c
+
+
+def _connect(client, mtls_config, timeout=10.0):
+    """Connect and wait for CONNACK. Returns the reason code, or None on timeout."""
+    client.connect_async(mtls_config["host"], mtls_config["port"], keepalive=30)
+    client.loop_start()
+    if not client._connack_event.wait(timeout=timeout):
+        return None
+    return client._rc
+
+
+def _close(client):
+    client.loop_stop()
+    try:
+        client.disconnect()
+    except Exception:
+        pass
+
+
+def _graphql(query, variables=None, headers=None):
+    return requests.post(GRAPHQL_URL,
+                         json={"query": query, "variables": variables or {}},
+                         headers=headers or {},
+                         timeout=10).json()
+
+
+def _admin_headers():
+    """Log in as admin, or skip when GraphQL/user management is not reachable."""
+    try:
+        result = _graphql(
+            "mutation($u: String!, $p: String!) { login(username: $u, password: $p) { success token } }",
+            {"u": ADMIN_USER, "p": ADMIN_PASSWORD},
+        )
+    except requests.RequestException:
+        pytest.skip("GraphQL endpoint not reachable at " + GRAPHQL_URL)
+    token = ((result.get("data") or {}).get("login") or {}).get("token")
+    if not token:
+        pytest.skip("Could not log in as admin for user management")
+    return {"Authorization": "Bearer " + token}
+
+
+def _delete_user(username, headers):
+    result = _graphql(
+        "mutation($u: String!) { user { deleteUser(username: $u) { success message } } }",
+        {"u": username},
+        headers,
+    )
+    return ((result.get("data") or {}).get("user") or {}).get("deleteUser") or {}
+
+
+def _get_user(username, headers):
+    result = _graphql(
+        "query($u: String) { users(username: $u) { username enabled canSubscribe canPublish isAdmin } }",
+        {"u": username},
+        headers,
+    )
+    users = (result.get("data") or {}).get("users") or []
+    return users[0] if users else None
+
+
+def _ensure_user(username, headers):
+    """Create the account for a certificate Common Name if it does not exist yet."""
+    if _get_user(username, headers) is not None:
+        return True
+    result = _graphql(
+        "mutation($u: String!, $p: String!) { user { createUser(input: {username: $u, password: $p}) "
+        "{ success message } } }",
+        {"u": username, "p": "cert-" + uuid.uuid4().hex},
+        headers,
+    )
+    created = ((result.get("data") or {}).get("user") or {}).get("createUser") or {}
+    return bool(created.get("success"))
+
+
+def _set_user_enabled(username, enabled, headers):
+    result = _graphql(
+        "mutation($u: String!, $e: Boolean!) { user { updateUser(input: {username: $u, enabled: $e}) "
+        "{ success message } } }",
+        {"u": username, "e": enabled},
+        headers,
+    )
+    return ((result.get("data") or {}).get("user") or {}).get("updateUser") or {}
+
+
+@pytest.fixture(autouse=True)
+def account_exists(request, mtls_config):
+    """With AutoCreateUser disabled the account must be pre-provisioned, so create it here.
+
+    Skipped for the test that deliberately removes the account.
+    """
+    if AUTO_CREATE == "0" and request.node.name != "test_unknown_common_name_rejected":
+        _ensure_user(mtls_config["common_name"], _admin_headers())
+    yield
+
+
+def test_connect_with_client_certificate(mtls_config):
+    """A client presenting a valid certificate connects without username or password."""
+    client = _make_client("cert_connect", mtls_config)
+    try:
+        rc = _connect(client, mtls_config)
+        assert rc is not None, "no CONNACK received"
+        assert rc == 0, "expected CONNACK 0, got {}".format(rc)
+    finally:
+        _close(client)
+
+
+def test_publish_and_subscribe_with_client_certificate(mtls_config):
+    """A certificate-authenticated client can actually publish and subscribe."""
+    topic = "test/mtls/{}".format(uuid.uuid4().hex[:8])
+    payload = "hello over mtls"
+
+    subscriber = _make_client("cert_sub", mtls_config)
+    publisher = _make_client("cert_pub", mtls_config)
+    try:
+        assert _connect(subscriber, mtls_config) == 0
+        subscriber.subscribe(topic, qos=1)
+        assert subscriber._suback_event.wait(timeout=5.0), "no SUBACK received"
+
+        assert _connect(publisher, mtls_config) == 0
+        publisher.publish(topic, payload, qos=1)
+
+        deadline = time.time() + 5.0
+        while time.time() < deadline and not subscriber._messages:
+            time.sleep(0.1)
+
+        assert subscriber._messages, "certificate-authenticated client received no message"
+        assert subscriber._messages[0] == (topic, payload)
+    finally:
+        _close(subscriber)
+        _close(publisher)
+
+
+def test_disabled_user_is_rejected(mtls_config):
+    """Disabling the account for a certificate Common Name blocks that client."""
+    headers = _admin_headers()
+    username = mtls_config["common_name"]
+
+    # Make sure the account exists by connecting once.
+    warmup = _make_client("cert_warmup", mtls_config)
+    try:
+        assert _connect(warmup, mtls_config) == 0
+    finally:
+        _close(warmup)
+
+    result = _set_user_enabled(username, False, headers)
+    if not result.get("success"):
+        pytest.skip("Could not disable user {}: {}".format(username, result.get("message")))
+
+    try:
+        client = _make_client("cert_disabled", mtls_config)
+        try:
+            rc = _connect(client, mtls_config, timeout=10.0)
+            assert rc != 0, "disabled user {} was allowed to connect (rc={})".format(username, rc)
+        finally:
+            _close(client)
+    finally:
+        _set_user_enabled(username, True, headers)
+
+
+def test_password_client_without_certificate(mtls_config):
+    """With ClientAuth REQUEST, a client with no certificate still uses username and password."""
+    client = _make_client("password_client", mtls_config,
+                          with_certificate=False,
+                          username=ADMIN_USER, password=ADMIN_PASSWORD)
+    try:
+        rc = _connect(client, mtls_config)
+        if rc is None:
+            pytest.skip("no CONNACK - broker may be configured with ClientAuth REQUIRED")
+        assert rc == 0, "expected CONNACK 0 for username/password client, got {}".format(rc)
+    finally:
+        _close(client)
+
+
+@pytest.mark.skipif(AUTO_CREATE != "1",
+                    reason="needs a broker with SSL.AutoCreateUser enabled (set MTLS_AUTO_CREATE_USER=1)")
+def test_account_created_on_first_connect(mtls_config):
+    """With AutoCreateUser enabled, a certificate without an account gets one, without admin rights."""
+    headers = _admin_headers()
+    username = mtls_config["common_name"]
+
+    _delete_user(username, headers)
+    assert _get_user(username, headers) is None, "account should not exist before the test"
+
+    client = _make_client("cert_autocreate", mtls_config)
+    try:
+        assert _connect(client, mtls_config) == 0, "client with a valid certificate could not connect"
+    finally:
+        _close(client)
+
+    created = _get_user(username, headers)
+    assert created is not None, "no account was created for the certificate Common Name"
+    assert created["enabled"] is True
+    assert created["isAdmin"] is False, "auto-created accounts must not be administrators"
+
+
+@pytest.mark.skipif(AUTO_CREATE != "0",
+                    reason="needs a broker with SSL.AutoCreateUser disabled (set MTLS_AUTO_CREATE_USER=0)")
+def test_unknown_common_name_rejected(mtls_config):
+    """With AutoCreateUser disabled, a certificate without an account is rejected."""
+    headers = _admin_headers()
+    username = mtls_config["common_name"]
+
+    result = _delete_user(username, headers)
+    if not result.get("success") and _get_user(username, headers) is not None:
+        pytest.skip("Could not remove account {} for the test".format(username))
+
+    try:
+        client = _make_client("cert_unknown", mtls_config)
+        try:
+            rc = _connect(client, mtls_config, timeout=10.0)
+            assert rc != 0, "certificate with no account was allowed to connect (rc={})".format(rc)
+        finally:
+            _close(client)
+    finally:
+        _ensure_user(username, headers)


### PR DESCRIPTION
Adds an optional `SSL.UseIdentityAsUsername` setting. When a client presents a certificate that was verified against the CA in `TrustStorePath`, the certificate Common Name is used as the authenticated identity and no password is required. Clients without a certificate keep using the normal username and password check, so both types can connect on the same port.

This is what we needed to move our device fleet over. The devices carry a client certificate only and send no credentials at all, so with `UserManagement` enabled they could not connect before this change.

## Changes

- `MqttClient.kt` - reads the Common Name from the verified peer certificate at CONNECT time and uses it as the authenticated user, skipping the password check. Falls back to the existing flow when no certificate is present.
- `MqttServer.kt` and `Monster.kt` - pass the new setting through to the MQTTS listener.
- `yaml-json-schema.json` - schema entry for the new option.
- `doc/security.md` - documents the option with an example.

Default is `false`, so existing setups behave exactly as before.

## Testing

Built from source and tested on Windows with Java 21 against real certificates from our own PKI (server certificate, CA, and a real device certificate), with `UserManagement.Enabled: true` and `ClientAuth: REQUEST`:

| Client | Result |
|---|---|
| Device certificate, no username or password | Connected, CONNACK 0x00, authenticated as the certificate Common Name |
| No certificate, no username or password | Rejected, CONNACK 0x05 not authorized |
| No certificate, with username and password | Connected, CONNACK 0x00 through the normal check |

One thing worth knowing when testing this: when `UserManagement` is enabled for the first time, the broker creates an `Anonymous` user that is enabled by default. While that user stays enabled, a client with no certificate and no credentials is still accepted. The `Anonymous` user has to be disabled for the check to be meaningful. That behavior is not changed by this PR.